### PR TITLE
add config to disable/enable processing of parity

### DIFF
--- a/minitel_server/constant.py
+++ b/minitel_server/constant.py
@@ -5,3 +5,4 @@ Created on 18 Oct 2019
 '''
 CFG_FILE = 'configuration.yaml'
 SIMULATE_12000_BPS = True
+PROCESS_PARITY = False

--- a/minitel_server/constant.py
+++ b/minitel_server/constant.py
@@ -5,4 +5,4 @@ Created on 18 Oct 2019
 '''
 CFG_FILE = 'configuration.yaml'
 SIMULATE_12000_BPS = True
-PROCESS_PARITY = False
+PROCESS_PARITY = True


### PR DESCRIPTION
In updated forks of softmodem for Asterisk, the parity processing is performed within the softmodem app. This PR provides a configuration constant to disable parity processing in the Minitel server terminal code.